### PR TITLE
feat(admin): add capture statistics and time-series visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A custom-built photo gallery and distribution platform for an Iowa-based physica
 *   **Unified CMS & Storage:** Both event metadata and high-resolution image assets are hosted on Sanity.io.
 *   **Event-Specific Branding:** Real-time styling updates (colors, fonts) driven by Sanity data.
 *   **Sanity Image Pipeline:** High-performance, optimized image delivery (WebP, auto-resize).
-*   **Admin Dashboard:** Per-event admin pages (`/[slug]/admin`) for managing and deleting images directly from the gallery.
+*   **Admin Dashboard:** Per-event admin pages (`/[slug]/admin`) with capture stats & time-series visualizations, remote print queue management, and batch photo deletion/ZIP downloading.
 *   **Batch Download:** One-click ZIP generation for organizers to download all event photos.
 
 ## 🛠️ Tech Stack

--- a/src/lib/CaptureAnalytics.svelte
+++ b/src/lib/CaptureAnalytics.svelte
@@ -1,0 +1,489 @@
+<script>
+	import { calculateCaptureStats, formatTimeShort } from './analytics';
+
+	/** @type {{ images?: Array<{ created?: string, name?: string }> }} */
+	let { images = [] } = $props();
+
+	let selectedInterval = $state(30);
+
+	/** @type {import('./analytics').TimelineBucket | null} */
+	let hoveredBucket = $state(null);
+
+	let stats = $derived(calculateCaptureStats(images, selectedInterval));
+
+	let maxBucketCount = $derived(
+		stats.timelineBuckets.reduce((max, b) => Math.max(max, b.count), 0) || 1
+	);
+
+	let maxHourlyCount = $derived(
+		stats.hourlyDistribution.reduce((max, h) => Math.max(max, h.count), 0) || 1
+	);
+
+	/** @param {number} mins */
+	function setInterval(mins) {
+		selectedInterval = mins;
+	}
+</script>
+
+<div class="analytics-card">
+	<div class="analytics-header">
+		<div class="header-info">
+			<h2>Capture Analytics</h2>
+			<p class="subtitle">Activity distribution & performance over time</p>
+		</div>
+
+		{#if images.length > 0}
+			<div class="interval-selector">
+				<span class="selector-label">Bucket:</span>
+				<button
+					type="button"
+					class="interval-btn"
+					class:active={selectedInterval === 15}
+					onclick={() => setInterval(15)}
+				>
+					15m
+				</button>
+				<button
+					type="button"
+					class="interval-btn"
+					class:active={selectedInterval === 30}
+					onclick={() => setInterval(30)}
+				>
+					30m
+				</button>
+				<button
+					type="button"
+					class="interval-btn"
+					class:active={selectedInterval === 60}
+					onclick={() => setInterval(60)}
+				>
+					1h
+				</button>
+			</div>
+		{/if}
+	</div>
+
+	{#if images.length === 0}
+		<div class="empty-analytics">
+			<span class="empty-icon">📊</span>
+			<p>No capture data recorded yet for this event.</p>
+		</div>
+	{:else}
+		<div class="stats-grid">
+			<div class="kpi-card">
+				<span class="kpi-label">Total Captures</span>
+				<span class="kpi-value">{stats.totalCaptures}</span>
+				<span class="kpi-sub">
+					{stats.overlaidCount} overlaid, {stats.rawCount} raw
+				</span>
+			</div>
+
+			<div class="kpi-card">
+				<span class="kpi-label">Capture Rate</span>
+				<span class="kpi-value">{stats.averageCapturesPerHour} <span class="unit">/hr</span></span>
+				<span class="kpi-sub">
+					Active over {stats.activeDurationMinutes} mins
+				</span>
+			</div>
+
+			<div class="kpi-card">
+				<span class="kpi-label">Peak Hour</span>
+				<span class="kpi-value">{stats.peakHourLabel}</span>
+				<span class="kpi-sub">
+					{stats.peakHourCount} captures during peak
+				</span>
+			</div>
+
+			<div class="kpi-card">
+				<span class="kpi-label">Active Timeframe</span>
+				<span class="kpi-value small">
+					{stats.firstCaptureTime ? formatTimeShort(stats.firstCaptureTime) : 'N/A'} - 
+					{stats.lastCaptureTime ? formatTimeShort(stats.lastCaptureTime) : 'N/A'}
+				</span>
+				<span class="kpi-sub">First to last capture</span>
+			</div>
+		</div>
+
+		<!-- Timeline Bar Chart -->
+		<div class="chart-section">
+			<div class="chart-header">
+				<h3>Captures Over Time</h3>
+				{#if hoveredBucket}
+					<div class="hover-tooltip">
+						<span class="tooltip-time">{hoveredBucket.label}</span>
+						<span class="tooltip-count">{hoveredBucket.count} photo{hoveredBucket.count === 1 ? '' : 's'}</span>
+						{#if hoveredBucket.isPeak}
+							<span class="peak-badge">Peak</span>
+						{/if}
+					</div>
+				{/if}
+			</div>
+
+			<div class="histogram-container">
+				<div class="histogram-bars">
+					{#each stats.timelineBuckets as bucket}
+						{@const heightPercent = Math.max((bucket.count / maxBucketCount) * 100, bucket.count > 0 ? 8 : 2)}
+						<div
+							class="bar-wrapper"
+							role="group"
+							aria-label="Capture bucket for {bucket.label}"
+							onmouseenter={() => (hoveredBucket = bucket)}
+							onmouseleave={() => (hoveredBucket = null)}
+						>
+							<div
+								class="bar"
+								class:has-captures={bucket.count > 0}
+								class:is-peak={bucket.isPeak}
+								style="height: {heightPercent}%;"
+							>
+								{#if bucket.count > 0}
+									<span class="bar-count">{bucket.count}</span>
+								{/if}
+							</div>
+							<span class="bar-label">{bucket.label}</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		</div>
+
+		<!-- 24-Hour Distribution Section -->
+		<div class="hourly-section">
+			<h3>24-Hour Activity Profile</h3>
+			<div class="hourly-grid">
+				{#each stats.hourlyDistribution as hourSlot}
+					{@const heightPercent = Math.max((hourSlot.count / maxHourlyCount) * 100, hourSlot.count > 0 ? 12 : 3)}
+					{@const isPeakHour = hourSlot.count > 0 && hourSlot.count === stats.peakHourCount}
+					<div
+						class="hourly-col"
+						title="{hourSlot.label}: {hourSlot.count} capture{hourSlot.count === 1 ? '' : 's'}"
+					>
+						<div
+							class="hourly-bar"
+							class:active={hourSlot.count > 0}
+							class:peak={isPeakHour}
+							style="height: {heightPercent}%;"
+						></div>
+						{#if hourSlot.hour % 3 === 0}
+							<span class="hourly-label">{hourSlot.label}</span>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.analytics-card {
+		background: var(--surface-secondary, #1a1e29);
+		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+		border-radius: 1rem;
+		padding: 1.5rem;
+		margin-bottom: 2rem;
+		box-shadow: var(--shadow-sm);
+	}
+
+	.analytics-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 1rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.header-info h2 {
+		font-size: 1.25rem;
+		font-weight: 700;
+		margin: 0;
+		color: var(--text-primary, #ffffff);
+	}
+
+	.subtitle {
+		font-size: 0.875rem;
+		color: var(--text-surface-secondary, #9ca3af);
+		margin: 0.25rem 0 0 0;
+	}
+
+	.interval-selector {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		background: var(--surface-primary, #111827);
+		padding: 0.25rem;
+		border-radius: 0.5rem;
+		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+	}
+
+	.selector-label {
+		font-size: 0.75rem;
+		color: var(--text-surface-secondary, #9ca3af);
+		padding: 0 0.5rem;
+		font-weight: 500;
+	}
+
+	.interval-btn {
+		background: transparent;
+		border: none;
+		color: var(--text-surface-secondary, #9ca3af);
+		padding: 0.25rem 0.625rem;
+		border-radius: 0.375rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition: all 0.2s ease;
+	}
+
+	.interval-btn:hover {
+		color: #ffffff;
+	}
+
+	.interval-btn.active {
+		background: var(--color-primary, #0153a4);
+		color: #ffffff;
+	}
+
+	.empty-analytics {
+		text-align: center;
+		padding: 3rem 1rem;
+		color: var(--text-surface-secondary, #9ca3af);
+	}
+
+	.empty-icon {
+		font-size: 2.5rem;
+		display: block;
+		margin-bottom: 0.5rem;
+	}
+
+	.stats-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		gap: 1rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.kpi-card {
+		background: var(--surface-primary, #111827);
+		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+		border-radius: 0.75rem;
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.kpi-label {
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-surface-secondary, #9ca3af);
+		margin-bottom: 0.25rem;
+	}
+
+	.kpi-value {
+		font-size: 1.5rem;
+		font-weight: 800;
+		color: var(--text-primary, #ffffff);
+		line-height: 1.2;
+	}
+
+	.kpi-value.small {
+		font-size: 1.125rem;
+	}
+
+	.unit {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--text-surface-secondary, #9ca3af);
+	}
+
+	.kpi-sub {
+		font-size: 0.75rem;
+		color: var(--text-surface-secondary, #9ca3af);
+		margin-top: 0.375rem;
+	}
+
+	.chart-section {
+		background: var(--surface-primary, #111827);
+		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.chart-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1rem;
+		min-height: 1.75rem;
+	}
+
+	.chart-header h3,
+	.hourly-section h3 {
+		font-size: 0.9375rem;
+		font-weight: 700;
+		margin: 0;
+		color: var(--text-primary, #ffffff);
+	}
+
+	.hover-tooltip {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		background: rgba(255, 255, 255, 0.1);
+		padding: 0.25rem 0.625rem;
+		border-radius: 0.375rem;
+		font-size: 0.75rem;
+	}
+
+	.tooltip-time {
+		color: var(--text-surface-secondary, #9ca3af);
+	}
+
+	.tooltip-count {
+		font-weight: 700;
+		color: var(--text-primary, #ffffff);
+	}
+
+	.peak-badge {
+		background: #f59e0b;
+		color: #000000;
+		font-size: 0.625rem;
+		font-weight: 800;
+		padding: 0.125rem 0.375rem;
+		border-radius: 0.25rem;
+		text-transform: uppercase;
+	}
+
+	.histogram-container {
+		width: 100%;
+		overflow-x: auto;
+		padding-bottom: 0.5rem;
+	}
+
+	.histogram-bars {
+		display: flex;
+		align-items: flex-end;
+		gap: 0.375rem;
+		height: 140px;
+		min-width: 100%;
+		padding-top: 1.5rem;
+		border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+	}
+
+	.bar-wrapper {
+		flex: 1;
+		min-width: 24px;
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+		align-items: center;
+		position: relative;
+		cursor: pointer;
+	}
+
+	.bar {
+		width: 100%;
+		max-width: 40px;
+		background: rgba(255, 255, 255, 0.08);
+		border-radius: 0.25rem 0.25rem 0 0;
+		transition: all 0.2s ease;
+		position: relative;
+		display: flex;
+		justify-content: center;
+	}
+
+	.bar.has-captures {
+		background: var(--color-primary, #0153a4);
+	}
+
+	.bar.is-peak {
+		background: linear-gradient(180deg, #f59e0b 0%, var(--color-primary, #0153a4) 100%);
+	}
+
+	.bar-wrapper:hover .bar {
+		filter: brightness(1.25);
+		transform: scaleY(1.02);
+	}
+
+	.bar-count {
+		position: absolute;
+		top: -1.25rem;
+		font-size: 0.6875rem;
+		font-weight: 700;
+		color: var(--text-primary, #ffffff);
+	}
+
+	.bar-label {
+		font-size: 0.6875rem;
+		color: var(--text-surface-secondary, #9ca3af);
+		margin-top: 0.5rem;
+		white-space: nowrap;
+	}
+
+	.hourly-section {
+		background: var(--surface-primary, #111827);
+		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+	}
+
+	.hourly-grid {
+		display: flex;
+		align-items: flex-end;
+		height: 80px;
+		gap: 2px;
+		margin-top: 1rem;
+		border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+		padding-bottom: 0.25rem;
+	}
+
+	.hourly-col {
+		flex: 1;
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+		align-items: center;
+		position: relative;
+	}
+
+	.hourly-bar {
+		width: 100%;
+		background: rgba(255, 255, 255, 0.05);
+		border-radius: 2px 2px 0 0;
+		transition: height 0.3s ease;
+	}
+
+	.hourly-bar.active {
+		background: var(--color-primary, #0153a4);
+		opacity: 0.7;
+	}
+
+	.hourly-bar.peak {
+		background: #f59e0b;
+		opacity: 1;
+	}
+
+	.hourly-label {
+		position: absolute;
+		bottom: -1.25rem;
+		font-size: 0.625rem;
+		color: var(--text-surface-secondary, #9ca3af);
+		white-space: nowrap;
+	}
+
+	@media (max-width: 640px) {
+		.analytics-header {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+
+		.stats-grid {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+</style>

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -56,7 +56,8 @@ export function formatHourLabel(hour) {
 
 /**
  * Determines whether a file represents a composite photobooth capture (and not a raw frame/individual shot).
- * Composite filename format example: 2026-07-31-17-08-26_pibooth.jpg
+ * Composite format example: 2026-07-31-17-08-26_pibooth.jpg
+ * Raw format examples: pibooth000.jpg, pibooth001.jpg, pibooth_1.jpg, pibooth_raw.jpg
  * @param {string} [name]
  * @returns {boolean}
  */
@@ -67,12 +68,15 @@ export function isCompositePhoto(name) {
 	// Exclude explicit raw indicators
 	if (lower.includes('raw')) return false;
 
-	// Exclude numbered frames like _pibooth_1.jpg, _pibooth_2.jpg, _pibooth_3.jpg
+	// Exclude raw frame patterns e.g. pibooth000.jpg, pibooth001.jpg, pibooth12.png
+	if (/pibooth\d+\.(jpg|jpeg|png|webp)$/i.test(lower)) return false;
+
+	// Exclude numbered frames after _pibooth like _pibooth_1.jpg, _pibooth_001.jpg
 	if (/_pibooth_\d+/i.test(lower)) return false;
 
-	// If the name contains pibooth, ensure it ends with _pibooth.<ext> or pibooth.<ext>
+	// If the name contains pibooth, ensure it ends with _pibooth.<ext> (preceded by timestamp)
 	if (lower.includes('pibooth')) {
-		return /_pibooth\.(jpg|jpeg|png|webp)$/i.test(lower) || /pibooth\.(jpg|jpeg|png|webp)$/i.test(lower);
+		return /_pibooth\.(jpg|jpeg|png|webp)$/i.test(lower);
 	}
 
 	return true;

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,208 @@
+/**
+ * @typedef {Object} TimelineBucket
+ * @property {string} label
+ * @property {Date} startTime
+ * @property {Date} endTime
+ * @property {number} count
+ * @property {boolean} isPeak
+ */
+
+/**
+ * @typedef {Object} HourlyDistribution
+ * @property {number} hour
+ * @property {string} label
+ * @property {number} count
+ */
+
+/**
+ * @typedef {Object} CaptureStats
+ * @property {number} totalCaptures
+ * @property {Date | null} firstCaptureTime
+ * @property {Date | null} lastCaptureTime
+ * @property {number} activeDurationMinutes
+ * @property {number} averageCapturesPerHour
+ * @property {number} overlaidCount
+ * @property {number} rawCount
+ * @property {string} peakHourLabel
+ * @property {number} peakHourCount
+ * @property {HourlyDistribution[]} hourlyDistribution
+ * @property {TimelineBucket[]} timelineBuckets
+ */
+
+/**
+ * Formats a Date object to a short time string (e.g., "7:30 PM")
+ * @param {Date} date
+ * @returns {string}
+ */
+export function formatTimeShort(date) {
+	if (!date || isNaN(date.getTime())) return '';
+	return new Intl.DateTimeFormat('en-US', {
+		hour: 'numeric',
+		minute: '2-digit',
+		hour12: true
+	}).format(date);
+}
+
+/**
+ * Formats hour index (0-23) to hour string (e.g. "7 PM")
+ * @param {number} hour
+ * @returns {string}
+ */
+export function formatHourLabel(hour) {
+	const period = hour >= 12 ? 'PM' : 'AM';
+	const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+	return `${displayHour} ${period}`;
+}
+
+/**
+ * Parses image list into valid sorted dates
+ * @param {Array<{ created?: string }>} images
+ * @returns {Date[]}
+ */
+export function getSortedCaptureDates(images) {
+	if (!Array.isArray(images)) return [];
+	return images
+		.map((img) => (img?.created ? new Date(img.created) : null))
+		.filter((date) => date && !isNaN(date.getTime()))
+		.sort((a, b) => a.getTime() - b.getTime());
+}
+
+/**
+ * Calculates capture statistics and histogram time buckets from an array of images.
+ * @param {Array<{ created?: string, name?: string }>} images
+ * @param {number} [intervalMinutes=30]
+ * @returns {CaptureStats}
+ */
+export function calculateCaptureStats(images = [], intervalMinutes = 30) {
+	const emptyResult = {
+		totalCaptures: 0,
+		firstCaptureTime: null,
+		lastCaptureTime: null,
+		activeDurationMinutes: 0,
+		averageCapturesPerHour: 0,
+		overlaidCount: 0,
+		rawCount: 0,
+		peakHourLabel: 'N/A',
+		peakHourCount: 0,
+		hourlyDistribution: Array.from({ length: 24 }, (_, i) => ({
+			hour: i,
+			label: formatHourLabel(i),
+			count: 0
+		})),
+		timelineBuckets: []
+	};
+
+	if (!Array.isArray(images) || images.length === 0) {
+		return emptyResult;
+	}
+
+	const dates = getSortedCaptureDates(images);
+	if (dates.length === 0) {
+		return emptyResult;
+	}
+
+	const totalCaptures = images.length;
+	const firstCaptureTime = dates[0];
+	const lastCaptureTime = dates[dates.length - 1];
+
+	const activeDurationMs = lastCaptureTime.getTime() - firstCaptureTime.getTime();
+	const activeDurationMinutes = Math.max(1, Math.round(activeDurationMs / (1000 * 60)));
+
+	// Average captures per hour during active duration
+	const durationHours = Math.max(activeDurationMinutes / 60, 1 / 60);
+	const averageCapturesPerHour = Number((totalCaptures / durationHours).toFixed(1));
+
+	// Photo classification (raw vs overlaid)
+	let rawCount = 0;
+	let overlaidCount = 0;
+	for (const img of images) {
+		const name = (img?.name || '').toLowerCase();
+		if (name.includes('raw')) {
+			rawCount++;
+		} else {
+			overlaidCount++;
+		}
+	}
+
+	// 24-hour distribution calculation
+	const hourlyCounts = Array(24).fill(0);
+	for (const d of dates) {
+		hourlyCounts[d.getHours()]++;
+	}
+
+	let peakHourIdx = 0;
+	let maxHourlyCount = 0;
+	for (let h = 0; h < 24; h++) {
+		if (hourlyCounts[h] > maxHourlyCount) {
+			maxHourlyCount = hourlyCounts[h];
+			peakHourIdx = h;
+		}
+	}
+
+	const hourlyDistribution = hourlyCounts.map((count, hour) => ({
+		hour,
+		label: formatHourLabel(hour),
+		count
+	}));
+
+	const peakHourLabel = maxHourlyCount > 0 ? formatHourLabel(peakHourIdx) : 'N/A';
+
+	// Timeline Buckets Generation
+	const safeInterval = Math.max(5, intervalMinutes);
+	const intervalMs = safeInterval * 60 * 1000;
+
+	// Align start time to floor interval
+	const startMs = Math.floor(firstCaptureTime.getTime() / intervalMs) * intervalMs;
+	const endMs = Math.ceil((lastCaptureTime.getTime() + 1) / intervalMs) * intervalMs;
+
+	const timelineBuckets = [];
+	let maxBucketCount = 0;
+
+	let currentMs = startMs;
+	while (currentMs < endMs) {
+		const bucketStart = new Date(currentMs);
+		const bucketEnd = new Date(currentMs + intervalMs);
+
+		// Count captures falling in [bucketStart, bucketEnd)
+		const count = dates.filter(
+			(d) => d.getTime() >= currentMs && d.getTime() < currentMs + intervalMs
+		).length;
+
+		if (count > maxBucketCount) {
+			maxBucketCount = count;
+		}
+
+		timelineBuckets.push({
+			label: formatTimeShort(bucketStart),
+			startTime: bucketStart,
+			endTime: bucketEnd,
+			count,
+			isPeak: false
+		});
+
+		currentMs += intervalMs;
+	}
+
+	// Mark peak buckets
+	if (maxBucketCount > 0) {
+		for (const bucket of timelineBuckets) {
+			if (bucket.count === maxBucketCount) {
+				bucket.isPeak = true;
+			}
+		}
+	}
+
+	return {
+		totalCaptures,
+		firstCaptureTime,
+		lastCaptureTime,
+		activeDurationMinutes,
+		averageCapturesPerHour,
+		overlaidCount,
+		rawCount,
+		peakHourLabel,
+		peakHourCount: maxHourlyCount,
+		hourlyDistribution,
+		timelineBuckets
+	};
+}

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -55,6 +55,30 @@ export function formatHourLabel(hour) {
 }
 
 /**
+ * Determines whether a file represents a composite photobooth capture (and not a raw frame/individual shot).
+ * Composite filename format example: 2026-07-31-17-08-26_pibooth.jpg
+ * @param {string} [name]
+ * @returns {boolean}
+ */
+export function isCompositePhoto(name) {
+	if (!name || typeof name !== 'string') return true;
+	const lower = name.toLowerCase();
+
+	// Exclude explicit raw indicators
+	if (lower.includes('raw')) return false;
+
+	// Exclude numbered frames like _pibooth_1.jpg, _pibooth_2.jpg, _pibooth_3.jpg
+	if (/_pibooth_\d+/i.test(lower)) return false;
+
+	// If the name contains pibooth, ensure it ends with _pibooth.<ext> or pibooth.<ext>
+	if (lower.includes('pibooth')) {
+		return /_pibooth\.(jpg|jpeg|png|webp)$/i.test(lower) || /pibooth\.(jpg|jpeg|png|webp)$/i.test(lower);
+	}
+
+	return true;
+}
+
+/**
  * Parses image list into valid sorted dates
  * @param {Array<{ created?: string }>} images
  * @returns {Date[]}
@@ -68,7 +92,8 @@ export function getSortedCaptureDates(images) {
 }
 
 /**
- * Calculates capture statistics and histogram time buckets from an array of images.
+ * Calculates capture statistics and histogram time buckets from an array of images,
+ * strictly counting composite photobooth captures (e.g., 2026-07-31-17-08-26_pibooth.jpg).
  * @param {Array<{ created?: string, name?: string }>} images
  * @param {number} [intervalMinutes=30]
  * @returns {CaptureStats}
@@ -96,12 +121,27 @@ export function calculateCaptureStats(images = [], intervalMinutes = 30) {
 		return emptyResult;
 	}
 
-	const dates = getSortedCaptureDates(images);
-	if (dates.length === 0) {
-		return emptyResult;
+	// Filter strictly for composite photos
+	const compositeImages = images.filter((img) => isCompositePhoto(img?.name));
+	const rawCount = images.length - compositeImages.length;
+	const overlaidCount = compositeImages.length;
+
+	if (compositeImages.length === 0) {
+		return {
+			...emptyResult,
+			rawCount
+		};
 	}
 
-	const totalCaptures = images.length;
+	const dates = getSortedCaptureDates(compositeImages);
+	if (dates.length === 0) {
+		return {
+			...emptyResult,
+			rawCount
+		};
+	}
+
+	const totalCaptures = compositeImages.length;
 	const firstCaptureTime = dates[0];
 	const lastCaptureTime = dates[dates.length - 1];
 
@@ -111,18 +151,6 @@ export function calculateCaptureStats(images = [], intervalMinutes = 30) {
 	// Average captures per hour during active duration
 	const durationHours = Math.max(activeDurationMinutes / 60, 1 / 60);
 	const averageCapturesPerHour = Number((totalCaptures / durationHours).toFixed(1));
-
-	// Photo classification (raw vs overlaid)
-	let rawCount = 0;
-	let overlaidCount = 0;
-	for (const img of images) {
-		const name = (img?.name || '').toLowerCase();
-		if (name.includes('raw')) {
-			rawCount++;
-		} else {
-			overlaidCount++;
-		}
-	}
 
 	// 24-hour distribution calculation
 	const hourlyCounts = Array(24).fill(0);

--- a/src/lib/analytics.test.js
+++ b/src/lib/analytics.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+	calculateCaptureStats,
+	formatHourLabel,
+	formatTimeShort,
+	getSortedCaptureDates
+} from './analytics';
+
+describe('analytics.js', () => {
+	it('formats hour labels correctly', () => {
+		expect(formatHourLabel(0)).toBe('12 AM');
+		expect(formatHourLabel(9)).toBe('9 AM');
+		expect(formatHourLabel(12)).toBe('12 PM');
+		expect(formatHourLabel(15)).toBe('3 PM');
+		expect(formatHourLabel(23)).toBe('11 PM');
+	});
+
+	it('handles empty image arrays gracefully', () => {
+		const result = calculateCaptureStats([]);
+		expect(result.totalCaptures).toBe(0);
+		expect(result.firstCaptureTime).toBeNull();
+		expect(result.lastCaptureTime).toBeNull();
+		expect(result.activeDurationMinutes).toBe(0);
+		expect(result.averageCapturesPerHour).toBe(0);
+		expect(result.peakHourLabel).toBe('N/A');
+		expect(result.timelineBuckets).toEqual([]);
+		expect(result.hourlyDistribution.length).toBe(24);
+	});
+
+	it('correctly calculates stats for mock captures', () => {
+		const mockImages = [
+			{ name: 'pibooth_01.jpg', created: '2026-07-31T18:00:00.000Z' },
+			{ name: 'pibooth_01_raw.jpg', created: '2026-07-31T18:05:00.000Z' },
+			{ name: 'pibooth_02.jpg', created: '2026-07-31T18:15:00.000Z' },
+			{ name: 'pibooth_03.jpg', created: '2026-07-31T18:45:00.000Z' },
+			{ name: 'pibooth_04.jpg', created: '2026-07-31T19:15:00.000Z' }
+		];
+
+		const stats = calculateCaptureStats(mockImages, 30);
+
+		expect(stats.totalCaptures).toBe(5);
+		expect(stats.rawCount).toBe(1);
+		expect(stats.overlaidCount).toBe(4);
+
+		expect(stats.firstCaptureTime).toEqual(new Date('2026-07-31T18:00:00.000Z'));
+		expect(stats.lastCaptureTime).toEqual(new Date('2026-07-31T19:15:00.000Z'));
+		expect(stats.activeDurationMinutes).toBe(75);
+
+		// Peak hour: hour 18 (6 PM UTC) has 4 captures
+		const peakHour = new Date('2026-07-31T18:00:00.000Z').getHours();
+		expect(stats.peakHourCount).toBe(4);
+		expect(stats.peakHourLabel).toBe(formatHourLabel(peakHour));
+
+		// Buckets for 30m intervals
+		expect(stats.timelineBuckets.length).toBeGreaterThan(0);
+		// Check sum of counts in timeline buckets equals total captures
+		const bucketSum = stats.timelineBuckets.reduce((acc, b) => acc + b.count, 0);
+		expect(bucketSum).toBe(5);
+	});
+
+	it('correctly marks peak timeline buckets', () => {
+		const mockImages = [
+			{ created: '2026-07-31T20:01:00.000Z' },
+			{ created: '2026-07-31T20:05:00.000Z' },
+			{ created: '2026-07-31T20:10:00.000Z' },
+			{ created: '2026-07-31T20:35:00.000Z' }
+		];
+
+		const stats = calculateCaptureStats(mockImages, 30);
+		const peakBuckets = stats.timelineBuckets.filter((b) => b.isPeak);
+
+		expect(peakBuckets.length).toBe(1);
+		expect(peakBuckets[0].count).toBe(3);
+	});
+});

--- a/src/lib/analytics.test.js
+++ b/src/lib/analytics.test.js
@@ -19,6 +19,14 @@ describe('analytics.js', () => {
 	it('identifies composite photobooth pictures vs raw frames', () => {
 		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth.jpg')).toBe(true);
 		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth.png')).toBe(true);
+
+		// Raw frame formats
+		expect(isCompositePhoto('pibooth000.jpg')).toBe(false);
+		expect(isCompositePhoto('pibooth001.jpg')).toBe(false);
+		expect(isCompositePhoto('pibooth002.jpg')).toBe(false);
+		expect(isCompositePhoto('pibooth003.jpg')).toBe(false);
+
+		// Other raw formats
 		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth_1.jpg')).toBe(false);
 		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth_2.jpg')).toBe(false);
 		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth_raw.jpg')).toBe(false);
@@ -37,11 +45,12 @@ describe('analytics.js', () => {
 		expect(result.hourlyDistribution.length).toBe(24);
 	});
 
-	it('filters out raw frames and counts only composite captures', () => {
+	it('filters out pibooth000.jpg raw frames and counts only composite captures', () => {
 		const mockImages = [
 			{ name: '2026-07-31-18-00-00_pibooth.jpg', created: '2026-07-31T18:00:00.000Z' },
-			{ name: '2026-07-31-18-00-00_pibooth_1.jpg', created: '2026-07-31T18:00:01.000Z' },
-			{ name: '2026-07-31-18-00-00_pibooth_2.jpg', created: '2026-07-31T18:00:02.000Z' },
+			{ name: 'pibooth000.jpg', created: '2026-07-31T18:00:01.000Z' },
+			{ name: 'pibooth001.jpg', created: '2026-07-31T18:00:02.000Z' },
+			{ name: 'pibooth002.jpg', created: '2026-07-31T18:00:03.000Z' },
 			{ name: '2026-07-31-18-15-00_pibooth.jpg', created: '2026-07-31T18:15:00.000Z' },
 			{ name: '2026-07-31-18-45-00_pibooth.jpg', created: '2026-07-31T18:45:00.000Z' },
 			{ name: '2026-07-31-19-15-00_pibooth.jpg', created: '2026-07-31T19:15:00.000Z' }
@@ -49,10 +58,10 @@ describe('analytics.js', () => {
 
 		const stats = calculateCaptureStats(mockImages, 30);
 
-		// Only 4 composite photos, 2 raw frames
+		// Only 4 composite photos, 3 raw frames (pibooth000, pibooth001, pibooth002)
 		expect(stats.totalCaptures).toBe(4);
 		expect(stats.overlaidCount).toBe(4);
-		expect(stats.rawCount).toBe(2);
+		expect(stats.rawCount).toBe(3);
 
 		expect(stats.firstCaptureTime).toEqual(new Date('2026-07-31T18:00:00.000Z'));
 		expect(stats.lastCaptureTime).toEqual(new Date('2026-07-31T19:15:00.000Z'));

--- a/src/lib/analytics.test.js
+++ b/src/lib/analytics.test.js
@@ -3,7 +3,8 @@ import {
 	calculateCaptureStats,
 	formatHourLabel,
 	formatTimeShort,
-	getSortedCaptureDates
+	getSortedCaptureDates,
+	isCompositePhoto
 } from './analytics';
 
 describe('analytics.js', () => {
@@ -13,6 +14,15 @@ describe('analytics.js', () => {
 		expect(formatHourLabel(12)).toBe('12 PM');
 		expect(formatHourLabel(15)).toBe('3 PM');
 		expect(formatHourLabel(23)).toBe('11 PM');
+	});
+
+	it('identifies composite photobooth pictures vs raw frames', () => {
+		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth.jpg')).toBe(true);
+		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth.png')).toBe(true);
+		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth_1.jpg')).toBe(false);
+		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth_2.jpg')).toBe(false);
+		expect(isCompositePhoto('2026-07-31-17-08-26_pibooth_raw.jpg')).toBe(false);
+		expect(isCompositePhoto('raw_photo.jpg')).toBe(false);
 	});
 
 	it('handles empty image arrays gracefully', () => {
@@ -27,43 +37,37 @@ describe('analytics.js', () => {
 		expect(result.hourlyDistribution.length).toBe(24);
 	});
 
-	it('correctly calculates stats for mock captures', () => {
+	it('filters out raw frames and counts only composite captures', () => {
 		const mockImages = [
-			{ name: 'pibooth_01.jpg', created: '2026-07-31T18:00:00.000Z' },
-			{ name: 'pibooth_01_raw.jpg', created: '2026-07-31T18:05:00.000Z' },
-			{ name: 'pibooth_02.jpg', created: '2026-07-31T18:15:00.000Z' },
-			{ name: 'pibooth_03.jpg', created: '2026-07-31T18:45:00.000Z' },
-			{ name: 'pibooth_04.jpg', created: '2026-07-31T19:15:00.000Z' }
+			{ name: '2026-07-31-18-00-00_pibooth.jpg', created: '2026-07-31T18:00:00.000Z' },
+			{ name: '2026-07-31-18-00-00_pibooth_1.jpg', created: '2026-07-31T18:00:01.000Z' },
+			{ name: '2026-07-31-18-00-00_pibooth_2.jpg', created: '2026-07-31T18:00:02.000Z' },
+			{ name: '2026-07-31-18-15-00_pibooth.jpg', created: '2026-07-31T18:15:00.000Z' },
+			{ name: '2026-07-31-18-45-00_pibooth.jpg', created: '2026-07-31T18:45:00.000Z' },
+			{ name: '2026-07-31-19-15-00_pibooth.jpg', created: '2026-07-31T19:15:00.000Z' }
 		];
 
 		const stats = calculateCaptureStats(mockImages, 30);
 
-		expect(stats.totalCaptures).toBe(5);
-		expect(stats.rawCount).toBe(1);
+		// Only 4 composite photos, 2 raw frames
+		expect(stats.totalCaptures).toBe(4);
 		expect(stats.overlaidCount).toBe(4);
+		expect(stats.rawCount).toBe(2);
 
 		expect(stats.firstCaptureTime).toEqual(new Date('2026-07-31T18:00:00.000Z'));
 		expect(stats.lastCaptureTime).toEqual(new Date('2026-07-31T19:15:00.000Z'));
-		expect(stats.activeDurationMinutes).toBe(75);
 
-		// Peak hour: hour 18 (6 PM UTC) has 4 captures
-		const peakHour = new Date('2026-07-31T18:00:00.000Z').getHours();
-		expect(stats.peakHourCount).toBe(4);
-		expect(stats.peakHourLabel).toBe(formatHourLabel(peakHour));
-
-		// Buckets for 30m intervals
-		expect(stats.timelineBuckets.length).toBeGreaterThan(0);
-		// Check sum of counts in timeline buckets equals total captures
+		// Sum of timeline buckets should match composite total (4)
 		const bucketSum = stats.timelineBuckets.reduce((acc, b) => acc + b.count, 0);
-		expect(bucketSum).toBe(5);
+		expect(bucketSum).toBe(4);
 	});
 
 	it('correctly marks peak timeline buckets', () => {
 		const mockImages = [
-			{ created: '2026-07-31T20:01:00.000Z' },
-			{ created: '2026-07-31T20:05:00.000Z' },
-			{ created: '2026-07-31T20:10:00.000Z' },
-			{ created: '2026-07-31T20:35:00.000Z' }
+			{ name: '2026-07-31-20-01-00_pibooth.jpg', created: '2026-07-31T20:01:00.000Z' },
+			{ name: '2026-07-31-20-05-00_pibooth.jpg', created: '2026-07-31T20:05:00.000Z' },
+			{ name: '2026-07-31-20-10-00_pibooth.jpg', created: '2026-07-31T20:10:00.000Z' },
+			{ name: '2026-07-31-20-35-00_pibooth.jpg', created: '2026-07-31T20:35:00.000Z' }
 		];
 
 		const stats = calculateCaptureStats(mockImages, 30);

--- a/src/routes/[slug]/admin/+layout.svelte
+++ b/src/routes/[slug]/admin/+layout.svelte
@@ -1,0 +1,41 @@
+<script>
+	/** @type {{ children?: import('svelte').Snippet }} */
+	let { children } = $props();
+</script>
+
+<div class="admin-theme-shell">
+	{#if children}
+		{@render children()}
+	{:else}
+		<slot />
+	{/if}
+</div>
+
+<style>
+	.admin-theme-shell {
+		/* Explicit, high-contrast Admin Dark Design Tokens */
+		--color-primary: #3b82f6;
+		--text-primary: #ffffff;
+		--color-secondary: #2563eb;
+		--text-secondary: #ffffff;
+		--surface-primary: #0f172a;
+		--surface-secondary: #1e293b;
+		--border-color: rgba(255, 255, 255, 0.12);
+		--text-surface-primary: #f8fafc;
+		--text-surface-secondary: #94a3b8;
+		--heading-font: 'Inter', system-ui, -apple-system, sans-serif;
+		--body-font: 'Inter', system-ui, -apple-system, sans-serif;
+
+		min-height: 100vh;
+		background-color: #0f172a !important;
+		color: #f8fafc !important;
+		font-family: var(--body-font);
+		padding: 1.5rem 1.5rem 4rem 1.5rem;
+		box-sizing: border-box;
+	}
+
+	:global(body) {
+		background-color: #0f172a !important;
+		color: #f8fafc !important;
+	}
+</style>

--- a/src/routes/[slug]/admin/+layout.svelte
+++ b/src/routes/[slug]/admin/+layout.svelte
@@ -4,11 +4,7 @@
 </script>
 
 <div class="admin-theme-shell">
-	{#if children}
-		{@render children()}
-	{:else}
-		<slot />
-	{/if}
+	{@render children?.()}
 </div>
 
 <style>

--- a/src/routes/[slug]/admin/+page.svelte
+++ b/src/routes/[slug]/admin/+page.svelte
@@ -6,6 +6,7 @@
 	export let form;
 	import { enhance } from '$app/forms';
 	import JSZip from 'jszip';
+	import CaptureAnalytics from '$lib/CaptureAnalytics.svelte';
 
 	let isDownloading = false;
 	let downloadProgress = '';
@@ -143,6 +144,8 @@
 
 <div class="admin-container">
 	<h1>Admin Dashboard</h1>
+
+	<CaptureAnalytics images={data.images} />
 
 	{#if form?.error}
 		<div class="alert alert-error">

--- a/src/routes/[slug]/admin/+page.svelte
+++ b/src/routes/[slug]/admin/+page.svelte
@@ -290,7 +290,7 @@
 		font-size: 2rem;
 		font-weight: 700;
 		margin-bottom: 2rem;
-		color: var(--color-primary);
+		color: var(--text-surface-primary, #f8fafc);
 	}
 
 	.admin-actions {

--- a/src/routes/[slug]/admin/login/+page.svelte
+++ b/src/routes/[slug]/admin/login/+page.svelte
@@ -32,12 +32,14 @@
 	}
 
 	.login-card {
-		background: white;
+		background: var(--surface-secondary, #1e293b);
 		padding: 2.5rem;
 		border-radius: 1rem;
-		box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+		box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
 		width: 100%;
 		max-width: 400px;
+		color: var(--text-surface-primary, #f8fafc);
 	}
 
 	h1 {
@@ -45,13 +47,13 @@
 		margin-bottom: 2rem;
 		text-align: center;
 		font-size: 1.75rem;
-		color: var(--color-primary);
+		color: var(--text-surface-primary, #f8fafc);
 	}
 
 	.error-message {
-		background-color: #fee2e2;
+		background-color: rgba(239, 68, 68, 0.2);
 		border: 1px solid #ef4444;
-		color: #b91c1c;
+		color: #ef4444;
 		padding: 0.75rem 1rem;
 		border-radius: 0.5rem;
 		margin-bottom: 1.5rem;
@@ -67,31 +69,31 @@
 		font-size: 0.875rem;
 		font-weight: 600;
 		margin-bottom: 0.5rem;
-		color: #374151;
+		color: var(--text-surface-secondary, #cbd5e1);
 	}
 
 	input {
 		width: 100%;
 		padding: 0.75rem;
-		border: 1px solid #d1d5db;
+		background: var(--surface-primary, #0f172a);
+		color: var(--text-surface-primary, #f8fafc);
+		border: 1px solid #475569;
 		border-radius: 0.5rem;
 		font-size: 1rem;
 		box-sizing: border-box;
-		transition:
-			border-color 0.2s,
-			ring 0.2s;
+		transition: border-color 0.2s;
 	}
 
 	input:focus {
 		outline: none;
-		border-color: var(--color-primary);
-		box-shadow: 0 0 0 3px rgba(1, 83, 164, 0.1);
+		border-color: var(--color-primary, #3b82f6);
+		box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
 	}
 
 	button {
 		width: 100%;
 		padding: 0.75rem;
-		background-color: var(--color-primary);
+		background-color: var(--color-primary, #3b82f6);
 		color: white;
 		border: none;
 		border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
Adds capture statistics and interactive time-series visualizations to the admin dashboard (/[slug]/admin).

### Highlights
- **KPI Metrics**: Total captures, active capture rate (photos/hr), peak activity window, active duration, and raw vs overlaid photo breakdown.
- **Histogram Visualizations**: Interactive timeline histogram with dynamic bucket selector (15m, 30m, 1h), hover tooltips, and peak indicators.
- **24-Hour Profile**: 24-hour activity profile bar chart.
- **Unit Tests**: Full unit test coverage for nalytics.js (un run test:unit).
- **Svelte 5 Runes**: Built using Svelte 5 runes (\, \, \).