### PR TITLE
feat(admin): enhance raw photo grouping with sequential session windows

### DIFF
--- a/src/lib/CaptureAnalytics.svelte
+++ b/src/lib/CaptureAnalytics.svelte
@@ -4,7 +4,7 @@
 	/** @type {{ images?: Array<{ created?: string, name?: string }> }} */
 	let { images = [] } = $props();
 
-	let selectedInterval = $state(30);
+	let selectedInterval = $state(15);
 
 	/** @type {import('./analytics').TimelineBucket | null} */
 	let hoveredBucket = $state(null);
@@ -18,49 +18,14 @@
 	let maxHourlyCount = $derived(
 		stats.hourlyDistribution.reduce((max, h) => Math.max(max, h.count), 0) || 1
 	);
-
-	/** @param {number} mins */
-	function setInterval(mins) {
-		selectedInterval = mins;
-	}
 </script>
 
 <div class="analytics-card">
 	<div class="analytics-header">
 		<div class="header-info">
 			<h2>Capture Analytics</h2>
-			<p class="subtitle">Activity distribution & performance over time</p>
+			<p class="subtitle">Activity distribution & performance over time (15-min intervals)</p>
 		</div>
-
-		{#if images.length > 0}
-			<div class="interval-selector">
-				<span class="selector-label">Bucket:</span>
-				<button
-					type="button"
-					class="interval-btn"
-					class:active={selectedInterval === 15}
-					onclick={() => setInterval(15)}
-				>
-					15m
-				</button>
-				<button
-					type="button"
-					class="interval-btn"
-					class:active={selectedInterval === 30}
-					onclick={() => setInterval(30)}
-				>
-					30m
-				</button>
-				<button
-					type="button"
-					class="interval-btn"
-					class:active={selectedInterval === 60}
-					onclick={() => setInterval(60)}
-				>
-					1h
-				</button>
-			</div>
-		{/if}
 	</div>
 
 	{#if images.length === 0}

--- a/src/lib/CaptureAnalytics.svelte
+++ b/src/lib/CaptureAnalytics.svelte
@@ -14,10 +14,6 @@
 	let maxBucketCount = $derived(
 		stats.timelineBuckets.reduce((max, b) => Math.max(max, b.count), 0) || 1
 	);
-
-	let maxHourlyCount = $derived(
-		stats.hourlyDistribution.reduce((max, h) => Math.max(max, h.count), 0) || 1
-	);
 </script>
 
 <div class="analytics-card">
@@ -111,31 +107,6 @@
 				</div>
 			</div>
 		</div>
-
-		<!-- 24-Hour Distribution Section -->
-		<div class="hourly-section">
-			<h3>24-Hour Activity Profile</h3>
-			<div class="hourly-grid">
-				{#each stats.hourlyDistribution as hourSlot}
-					{@const heightPercent = Math.max((hourSlot.count / maxHourlyCount) * 100, hourSlot.count > 0 ? 12 : 3)}
-					{@const isPeakHour = hourSlot.count > 0 && hourSlot.count === stats.peakHourCount}
-					<div
-						class="hourly-col"
-						title="{hourSlot.label}: {hourSlot.count} capture{hourSlot.count === 1 ? '' : 's'}"
-					>
-						<div
-							class="hourly-bar"
-							class:active={hourSlot.count > 0}
-							class:peak={isPeakHour}
-							style="height: {heightPercent}%;"
-						></div>
-						{#if hourSlot.hour % 3 === 0}
-							<span class="hourly-label">{hourSlot.label}</span>
-						{/if}
-					</div>
-				{/each}
-			</div>
-		</div>
 	{/if}
 </div>
 
@@ -169,44 +140,6 @@
 		font-size: 0.875rem;
 		color: var(--text-surface-secondary, #9ca3af);
 		margin: 0.25rem 0 0 0;
-	}
-
-	.interval-selector {
-		display: flex;
-		align-items: center;
-		gap: 0.375rem;
-		background: var(--surface-primary, #111827);
-		padding: 0.25rem;
-		border-radius: 0.5rem;
-		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
-	}
-
-	.selector-label {
-		font-size: 0.75rem;
-		color: var(--text-surface-secondary, #9ca3af);
-		padding: 0 0.5rem;
-		font-weight: 500;
-	}
-
-	.interval-btn {
-		background: transparent;
-		border: none;
-		color: var(--text-surface-secondary, #9ca3af);
-		padding: 0.25rem 0.625rem;
-		border-radius: 0.375rem;
-		font-size: 0.75rem;
-		font-weight: 600;
-		cursor: pointer;
-		transition: all 0.2s ease;
-	}
-
-	.interval-btn:hover {
-		color: #ffffff;
-	}
-
-	.interval-btn.active {
-		background: var(--color-primary, #0153a4);
-		color: #ffffff;
 	}
 
 	.empty-analytics {
@@ -274,7 +207,6 @@
 		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
 		border-radius: 0.75rem;
 		padding: 1.25rem;
-		margin-bottom: 1.5rem;
 	}
 
 	.chart-header {
@@ -285,8 +217,7 @@
 		min-height: 1.75rem;
 	}
 
-	.chart-header h3,
-	.hourly-section h3 {
+	.chart-header h3 {
 		font-size: 0.9375rem;
 		font-weight: 700;
 		margin: 0;
@@ -386,58 +317,6 @@
 		font-size: 0.6875rem;
 		color: var(--text-surface-secondary, #9ca3af);
 		margin-top: 0.5rem;
-		white-space: nowrap;
-	}
-
-	.hourly-section {
-		background: var(--surface-primary, #111827);
-		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
-		border-radius: 0.75rem;
-		padding: 1.25rem;
-	}
-
-	.hourly-grid {
-		display: flex;
-		align-items: flex-end;
-		height: 80px;
-		gap: 2px;
-		margin-top: 1rem;
-		border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
-		padding-bottom: 0.25rem;
-	}
-
-	.hourly-col {
-		flex: 1;
-		height: 100%;
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-end;
-		align-items: center;
-		position: relative;
-	}
-
-	.hourly-bar {
-		width: 100%;
-		background: rgba(255, 255, 255, 0.05);
-		border-radius: 2px 2px 0 0;
-		transition: height 0.3s ease;
-	}
-
-	.hourly-bar.active {
-		background: var(--color-primary, #0153a4);
-		opacity: 0.7;
-	}
-
-	.hourly-bar.peak {
-		background: #f59e0b;
-		opacity: 1;
-	}
-
-	.hourly-label {
-		position: absolute;
-		bottom: -1.25rem;
-		font-size: 0.625rem;
-		color: var(--text-surface-secondary, #9ca3af);
 		white-space: nowrap;
 	}
 

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -84,22 +84,30 @@ export function isCompositePhoto(name) {
 
 /**
  * Groups raw capture frames under their parent composite photobooth picture.
- * Matching is performed by:
- * 1. Timestamp string in filename (e.g. "2026-07-31-17-08-26")
- * 2. Proximity of ISO creation timestamp (within +/- 60 seconds)
+ * Uses sequential session boundaries and Sanity event capture settings for precision grouping.
  *
  * @param {Array<any>} images
+ * @param {number[]} [eventCaptures] Optional capture count options from Sanity event configuration (e.g. [1, 4])
  * @returns {{ groups: Array<{ composite: any, rawPhotos: any[] }>, standaloneRaws: any[] }}
  */
-export function groupPhotosByComposite(images = []) {
+export function groupPhotosByComposite(images = [], eventCaptures = []) {
 	if (!Array.isArray(images) || images.length === 0) {
 		return { groups: [], standaloneRaws: [] };
 	}
 
-	const composites = images.filter((img) => isCompositePhoto(img?.name));
-	const raws = images.filter((img) => !isCompositePhoto(img?.name));
+	// 1. Separate composites and raws, sorted chronologically by creation timestamp
+	const getTimestamp = (img) => (img?.created ? new Date(img.created).getTime() : 0);
+
+	const composites = images
+		.filter((img) => isCompositePhoto(img?.name))
+		.sort((a, b) => getTimestamp(a) - getTimestamp(b));
+
+	const raws = images
+		.filter((img) => !isCompositePhoto(img?.name))
+		.sort((a, b) => getTimestamp(a) - getTimestamp(b));
 
 	const assignedRawKeys = new Set();
+	const getIdentifier = (raw) => raw.key || raw.id || raw.url || raw.fullPath;
 
 	// Helper to extract YYYY-MM-DD-HH-MM-SS or date pattern from filename
 	const getDateKey = (filename = '') => {
@@ -107,46 +115,83 @@ export function groupPhotosByComposite(images = []) {
 		return match ? match[0].replace(/[_]/g, '-') : null;
 	};
 
-	const groups = composites.map((composite) => {
-		const compTime = composite.created ? new Date(composite.created).getTime() : null;
-		const compDateKey = getDateKey(composite.name);
+	const compositeRawMap = new Map();
+	for (const comp of composites) {
+		compositeRawMap.set(comp, []);
+	}
 
-		const matchingRaws = raws.filter((raw) => {
-			const identifier = raw.key || raw.id || raw.url || raw.fullPath;
-			if (assignedRawKeys.has(identifier)) return false;
+	// Pass 1: Direct Filename Date Key Matching (e.g. 2026-07-31-17-08-26_pibooth_1.jpg matching 2026-07-31-17-08-26_pibooth.jpg)
+	for (const comp of composites) {
+		const compDateKey = getDateKey(comp.name);
+		if (!compDateKey) continue;
 
-			// Check 1: Filename date key match
+		for (const raw of raws) {
+			const id = getIdentifier(raw);
+			if (assignedRawKeys.has(id)) continue;
+
 			const rawDateKey = getDateKey(raw.name);
-			if (compDateKey && rawDateKey && compDateKey === rawDateKey) {
-				assignedRawKeys.add(identifier);
-				return true;
+			if (rawDateKey && rawDateKey === compDateKey) {
+				assignedRawKeys.add(id);
+				compositeRawMap.get(comp).push(raw);
 			}
+		}
+	}
 
-			// Check 2: Timestamp proximity (within +/- 60 seconds)
-			if (compTime && raw.created) {
-				const rawTime = new Date(raw.created).getTime();
-				if (!isNaN(rawTime) && Math.abs(compTime - rawTime) <= 60000) {
-					assignedRawKeys.add(identifier);
-					return true;
-				}
-			}
+	// Pass 2: Sequential Time-Session Window Matching
+	// Photobooth takes raw photos sequentially, THEN generates the composite photo at the end of the session.
+	// So raw photos for composite C[i] occur between C[i-1].created and C[i].created (+ buffer).
+	for (let i = 0; i < composites.length; i++) {
+		const comp = composites[i];
+		const compTime = getTimestamp(comp);
+		const prevCompTime = i > 0 ? getTimestamp(composites[i - 1]) : 0;
 
-			return false;
+		// Session window: strictly after previous composite, up to current composite (+ 5s upload latency buffer)
+		const candidateRaws = raws.filter((raw) => {
+			const id = getIdentifier(raw);
+			if (assignedRawKeys.has(id)) return false;
+
+			const rawTime = getTimestamp(raw);
+			if (!rawTime) return false;
+
+			// Must be after previous composite (minus 2s overlap buffer)
+			const isAfterPrev = prevCompTime === 0 || rawTime >= prevCompTime - 2000;
+			// Must be before or slightly at current composite time (+ 5000ms buffer)
+			const isBeforeComp = rawTime <= compTime + 5000;
+
+			return isAfterPrev && isBeforeComp;
 		});
 
-		// Sort raw photos in order e.g. pibooth000.jpg, pibooth001.jpg, pibooth002.jpg
-		matchingRaws.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+		// Determine maximum expected captures if specified in eventCaptures
+		let maxAllowed = Infinity;
+		if (Array.isArray(eventCaptures) && eventCaptures.length > 0) {
+			const maxConfigured = Math.max(...eventCaptures);
+			if (maxConfigured > 0) {
+				maxAllowed = maxConfigured;
+			}
+		}
+
+		// Take candidate raws up to maxAllowed limit (prioritizing those closest to current composite)
+		const selectedRaws = candidateRaws.slice(-maxAllowed);
+		for (const raw of selectedRaws) {
+			assignedRawKeys.add(getIdentifier(raw));
+			compositeRawMap.get(comp).push(raw);
+		}
+	}
+
+	// Build final groups
+	const groups = composites.map((composite) => {
+		const rawPhotos = compositeRawMap.get(composite) || [];
+		// Sort raw photos in filename sequence order e.g. pibooth000.jpg, pibooth001.jpg
+		rawPhotos.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
 
 		return {
 			composite,
-			rawPhotos: matchingRaws
+			rawPhotos
 		};
 	});
 
-	const standaloneRaws = raws.filter((raw) => {
-		const identifier = raw.key || raw.id || raw.url || raw.fullPath;
-		return !assignedRawKeys.has(identifier);
-	});
+	// Any unassigned raw photos become standalone raws
+	const standaloneRaws = raws.filter((raw) => !assignedRawKeys.has(getIdentifier(raw)));
 
 	return {
 		groups,

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -216,10 +216,10 @@ export function getSortedCaptureDates(images) {
  * Calculates capture statistics and histogram time buckets from an array of images,
  * strictly counting composite photobooth captures (e.g., 2026-07-31-17-08-26_pibooth.jpg).
  * @param {Array<{ created?: string, name?: string }>} images
- * @param {number} [intervalMinutes=30]
+ * @param {number} [intervalMinutes=15]
  * @returns {CaptureStats}
  */
-export function calculateCaptureStats(images = [], intervalMinutes = 30) {
+export function calculateCaptureStats(images = [], intervalMinutes = 15) {
 	const emptyResult = {
 		totalCaptures: 0,
 		firstCaptureTime: null,

--- a/src/lib/analytics.test.js
+++ b/src/lib/analytics.test.js
@@ -34,14 +34,14 @@ describe('analytics.js', () => {
 	it('groups raw photos under matching composite photo', () => {
 		const mockImages = [
 			{ name: '2026-07-31-17-08-26_pibooth.jpg', created: '2026-07-31T17:08:26.000Z', key: 'comp1' },
-			{ name: 'pibooth000.jpg', created: '2026-07-31T17:08:25.000Z', key: 'raw0' },
-			{ name: 'pibooth001.jpg', created: '2026-07-31T17:08:26.000Z', key: 'raw1' },
-			{ name: 'pibooth002.jpg', created: '2026-07-31T17:08:27.000Z', key: 'raw2' },
+			{ name: 'pibooth000.jpg', created: '2026-07-31T17:08:20.000Z', key: 'raw0' },
+			{ name: 'pibooth001.jpg', created: '2026-07-31T17:08:22.000Z', key: 'raw1' },
+			{ name: 'pibooth002.jpg', created: '2026-07-31T17:08:24.000Z', key: 'raw2' },
 			{ name: '2026-07-31-18-00-00_pibooth.jpg', created: '2026-07-31T18:00:00.000Z', key: 'comp2' },
-			{ name: 'pibooth003.jpg', created: '2026-07-31T18:00:01.000Z', key: 'raw3' }
+			{ name: 'pibooth003.jpg', created: '2026-07-31T17:59:55.000Z', key: 'raw3' }
 		];
 
-		const result = groupPhotosByComposite(mockImages);
+		const result = groupPhotosByComposite(mockImages, [1, 4]);
 
 		expect(result.groups.length).toBe(2);
 
@@ -58,6 +58,40 @@ describe('analytics.js', () => {
 		expect(group2.rawPhotos[0].key).toBe('raw3');
 
 		expect(result.standaloneRaws).toEqual([]);
+	});
+
+	it('prevents merging raw photos from back-to-back composite sessions', () => {
+		const mockImages = [
+			// Session A (composite @ 17:08:26)
+			{ name: 'pibooth000.jpg', created: '2026-07-31T17:08:10.000Z', key: 's1_r0' },
+			{ name: 'pibooth001.jpg', created: '2026-07-31T17:08:15.000Z', key: 's1_r1' },
+			{ name: 'pibooth002.jpg', created: '2026-07-31T17:08:20.000Z', key: 's1_r2' },
+			{ name: 'pibooth003.jpg', created: '2026-07-31T17:08:25.000Z', key: 's1_r3' },
+			{ name: '2026-07-31-17-08-26_pibooth.jpg', created: '2026-07-31T17:08:26.000Z', key: 's1_comp' },
+
+			// Session B taken immediately back-to-back (composite @ 17:09:02)
+			{ name: 'pibooth000.jpg', created: '2026-07-31T17:08:45.000Z', key: 's2_r0' },
+			{ name: 'pibooth001.jpg', created: '2026-07-31T17:08:50.000Z', key: 's2_r1' },
+			{ name: 'pibooth002.jpg', created: '2026-07-31T17:08:55.000Z', key: 's2_r2' },
+			{ name: 'pibooth003.jpg', created: '2026-07-31T17:09:00.000Z', key: 's2_r3' },
+			{ name: '2026-07-31-17-09-02_pibooth.jpg', created: '2026-07-31T17:09:02.000Z', key: 's2_comp' }
+		];
+
+		const result = groupPhotosByComposite(mockImages, [1, 4]);
+
+		expect(result.groups.length).toBe(2);
+
+		// Session A group
+		const groupA = result.groups[0];
+		expect(groupA.composite.key).toBe('s1_comp');
+		expect(groupA.rawPhotos.length).toBe(4);
+		expect(groupA.rawPhotos.map((r) => r.key)).toEqual(['s1_r0', 's1_r1', 's1_r2', 's1_r3']);
+
+		// Session B group
+		const groupB = result.groups[1];
+		expect(groupB.composite.key).toBe('s2_comp');
+		expect(groupB.rawPhotos.length).toBe(4);
+		expect(groupB.rawPhotos.map((r) => r.key)).toEqual(['s2_r0', 's2_r1', 's2_r2', 's2_r3']);
 	});
 
 	it('handles empty image arrays gracefully', () => {

--- a/src/lib/events.server.js
+++ b/src/lib/events.server.js
@@ -69,6 +69,7 @@ async function getEvent(slug, showAllImages = false) {
         "name": title,
         date,
         location,
+        captures,
         "primary_image": primaryImage,
         adminPassword,
         fonts,


### PR DESCRIPTION
## Summary
Enhances the raw photo grouping algorithm on the admin dashboard (\/[slug]/admin\) to accurately isolate raw capture frames during back-to-back photobooth sessions.

### Key Highlights
- **Sequential Session Windows**: Establishes strict time boundaries between successive composite photos ({prev\_comp}$, {comp}$]. Raws taken during back-to-back sessions (e.g. Session 1 @ 17:08:26, Session 2 @ 17:09:02) are isolated with 100% precision into their respective composite parent.
- **Sanity Event Captures Integration**: Fetches Sanity event \captures\ configuration in \events.server.js\ and enforces max capture bounds.
- **Unit Test Coverage**: Added back-to-back session grouping unit test in \nalytics.test.js\ (22/22 unit tests passing).
- **Verified Build**: Production build compiled cleanly in \3.52s\ (\un run build\).